### PR TITLE
client: allow matching any service class in spn

### DIFF
--- a/v9/client/settings.go
+++ b/v9/client/settings.go
@@ -19,6 +19,7 @@ type Settings struct {
 	preAuthEType            int32
 	logger                  *log.Logger
 	dialer                  KDCDialer
+	anyServiceClassSPN      bool
 }
 
 // jsonSettings is used when marshaling the Settings details to JSON format.
@@ -56,6 +57,17 @@ func (s *Settings) DisablePAFXFAST() bool {
 func AssumePreAuthentication(b bool) func(*Settings) {
 	return func(s *Settings) {
 		s.assumePreAuthentication = b
+	}
+}
+
+// AnyServiceClassSPN used to configure the client to allow using tickets
+// matching target SPN that does not match the service class of the target service.
+// Microsoft Services do not require the service class to match the target SPN.
+//
+// s := NewSettings(AnyServiceClassSPN(true))
+func AnyServiceClassSPN(b bool) func(*Settings) {
+	return func(s *Settings) {
+		s.anyServiceClassSPN = b
 	}
 }
 

--- a/v9/types/PrincipalName.go
+++ b/v9/types/PrincipalName.go
@@ -47,6 +47,11 @@ func (pn PrincipalName) Equal(n PrincipalName) bool {
 	return true
 }
 
+func (pn PrincipalName) EqualHostName(n PrincipalName) bool {
+	return len(pn.NameString) >= 2 && len(n.NameString) >= 2 &&
+		pn.NameString[len(pn.NameString)-1] == n.NameString[len(n.NameString)-1]
+}
+
 // PrincipalNameString returns the PrincipalName in string form.
 func (pn PrincipalName) PrincipalNameString() string {
 	return strings.Join(pn.NameString, "/")


### PR DESCRIPTION
this change introduces the new option AnyServiceClassSPN() to allow matching the service ticket by hostname only, thus ignoring the service class (like cifs/ host/ and so on).